### PR TITLE
Resolve bug with single line SPDX Identifier match

### DIFF
--- a/parsers/guesser.go
+++ b/parsers/guesser.go
@@ -39,7 +39,7 @@ var DocumentName = ""
 var PackageName = ""
 var DocumentNamespace = ""
 
-var spdxLicenceRegex = regexp.MustCompile(`SPDX-License-Identifier:\s+(.*)[ |\n|\r\n]`)
+var spdxLicenceRegex = regexp.MustCompile(`SPDX-License-Identifier:\s+(.*)[ |\n|\r\n]*?`)
 var alphaNumericRegex = regexp.MustCompile("[^a-zA-Z0-9 ]")
 var multipleSpacesRegex = regexp.MustCompile("\\s+")
 

--- a/parsers/guesser_test.go
+++ b/parsers/guesser_test.go
@@ -128,3 +128,28 @@ func TestProcessFileLicensesTop10(t *testing.T) {
 		}
 	}
 }
+
+func TestIdentifierGuessLicence(t *testing.T) {
+	actual := identifierGuessLicence("test", loadDatabase())
+	if len(actual) != 0 {
+		t.Errorf("Should be no matches")
+	}
+
+	actual = identifierGuessLicence("# SPDX-License-Identifier: GPL-2.0", loadDatabase())
+	if actual[0].LicenseId != "GPL-2.0" {
+		t.Errorf("Should match GPL-2.0")
+	}
+
+	actual = identifierGuessLicence("# SPDX-License-Identifier: GPL-2.0 ", loadDatabase())
+	if actual[0].LicenseId != "GPL-2.0" {
+		t.Errorf("Should match GPL-2.0")
+	}
+
+	actual = identifierGuessLicence("# SPDX-License-Identifier: GPL-2.0 \n # SPDX-License-Identifier: GPL-3.0+", loadDatabase())
+	if actual[0].LicenseId != "GPL-2.0" {
+		t.Errorf("Should match GPL-2.0")
+	}
+	if actual[1].LicenseId != "GPL-3.0+" {
+		t.Errorf("Should match GPL-3.0+")
+	}
+}


### PR DESCRIPTION
Found a bug in the regular expression for SPDX Identifier matches that would fail if a file consisted of just the Identifier, E.G.

```
# SPDX-License-Identifier: GPL-2.0
```
This adds some tests over the method itself and resolves the bug.
