### PR TITLE
fixed license mismatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-* Before submitting, please specify that you explicitly licence your contribution under GPL-3.0-only.
+* Before submitting, please specify that you explicitly licence your contribution under MIT License AND UNLICENSE.
 
 * If you include compatible code from a third party souce with an altunate license please add a SDPX tag to indicate this, see https://github.com/boyter/lc/blob/master/parsers/helpers.go bytesToHuman function as a reference exmaple.
 


### PR DESCRIPTION
In one moment License has changed from GPL-3.0-only to MIT License and UNLICENSE

https://github.com/boyter/lc/commit/882973b01bb1954c2d13f6c185e023c35db84446

It's possible that CONTRIBUTING.md remained with GPL-3.0?
